### PR TITLE
sync POC with chart and prod defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,10 @@ The structure is designed to support future AWS and Azure deployments, but curre
 - Safe upgrade path: customer configs never conflict with repo updates
 
 ### Network Configuration
-The POC environment uses existing VPC infrastructure:
-- **Default**: Uses GCP default VPC (simplest, works for most POCs)
-- **Enterprise**: Uses existing customer VPC by setting `vpc_name` and `subnet_name`
+The POC environment always provisions a dedicated VPC:
+- VPC + subnet `10.0.0.0/24` in the configured region
+- Secondary ranges for GKE pods (`10.4.0.0/14`) and services (`10.8.0.0/20`) added when `enable_gke = true`
+- Cloud Router + Cloud NAT for egress from private nodes
 
 ### Core Infrastructure Components
 

--- a/terraform/environments/poc/README.md
+++ b/terraform/environments/poc/README.md
@@ -144,6 +144,10 @@ kubectl get nodes
 ## Upgrading
 Your configuration is safe during upgrades - see [UPGRADE.md](../../../UPGRADE.md) for details.
 
+## Out of Scope
+Conductor/maestro requires its own PostgreSQL database (`maestro` DB and user, see `charts/maestro/values.yaml`). This POC terraform does not provision it.
+Operators wanting to run conductor alongside lakerunner must create that database manually on the same Cloud SQL instance.
+
 ## Cleanup
 
 To remove all resources:

--- a/terraform/environments/poc/main.tf
+++ b/terraform/environments/poc/main.tf
@@ -314,10 +314,10 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   network                 = google_compute_network.lakerunner_vpc.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address[0].name]
-  deletion_policy         = "ABANDON"  # Required to prevent interfering with other installations
+  deletion_policy         = "ABANDON" # Required to prevent interfering with other installations
 
   depends_on = [google_project_service.service_networking, google_project_service.sql_admin]
-  
+
   lifecycle {
     create_before_destroy = false
   }
@@ -378,7 +378,7 @@ resource "google_sql_database" "lakerunner_database" {
 # Create configdb database for Lakerunner configuration
 resource "google_sql_database" "lakerunner_configdb" {
   count    = var.create_postgresql ? 1 : 0
-  name     = "configdb"
+  name     = var.postgresql_configdb_name
   instance = google_sql_database_instance.lakerunner_postgresql[0].name
 }
 

--- a/terraform/environments/poc/outputs.tf
+++ b/terraform/environments/poc/outputs.tf
@@ -14,6 +14,11 @@ output "object_notifications_topic" {
   value       = google_pubsub_topic.object_notifications.name
 }
 
+output "pubsub_subscription_id" {
+  description = "Pub/Sub subscription for object notifications"
+  value       = google_pubsub_subscription.lakerunner_notifications.name
+}
+
 
 output "project_id" {
   description = "GCP Project ID used for this POC"
@@ -80,7 +85,7 @@ output "postgresql_database_name" {
 
 output "postgresql_configdb_name" {
   description = "PostgreSQL configdb name"
-  value       = "configdb"
+  value       = var.postgresql_configdb_name
 }
 
 output "postgresql_user" {
@@ -182,12 +187,13 @@ output "deployment_summary" {
     Storage:
       Lakerunner Bucket: ${google_storage_bucket.lakerunner.name}
       Notifications Topic: ${google_pubsub_topic.object_notifications.name}
+      Notifications Subscription: ${google_pubsub_subscription.lakerunner_notifications.name}
       S3 Compatible Access:
         Endpoint: https://storage.googleapis.com
         Access Key: ${google_storage_hmac_key.lakerunner_s3_key.access_id}
         Secret Key: [SENSITIVE - use 'terraform output -raw s3_secret_key' to view]
         Region: auto
-      ${var.create_postgresql ? "Database:\n      PostgreSQL Instance: ${google_sql_database_instance.lakerunner_postgresql[0].name}\n      Databases: ${var.postgresql_database_name}, configdb\n      User: ${var.postgresql_user}\n      Private IP: ${google_sql_database_instance.lakerunner_postgresql[0].private_ip_address}\n      Both lrdb and configdb ready for Lakerunner" : "Enable PostgreSQL with create_postgresql=true for database support"}
+      ${var.create_postgresql ? "Database:\n      PostgreSQL Instance: ${google_sql_database_instance.lakerunner_postgresql[0].name}\n      Databases: ${var.postgresql_database_name}, ${var.postgresql_configdb_name}\n      User: ${var.postgresql_user}\n      Private IP: ${google_sql_database_instance.lakerunner_postgresql[0].private_ip_address}\n      Both lrdb and configdb ready for Lakerunner" : "Enable PostgreSQL with create_postgresql=true for database support"}
 
     Network:
       VPC: ${google_compute_network.lakerunner_vpc.name} (dedicated)

--- a/terraform/environments/poc/variables.tf
+++ b/terraform/environments/poc/variables.tf
@@ -116,6 +116,12 @@ variable "postgresql_database_name" {
   default     = "lakerunner"
 }
 
+variable "postgresql_configdb_name" {
+  description = "PostgreSQL configdb database name for Lakerunner"
+  type        = string
+  default     = "config"
+}
+
 variable "postgresql_user" {
   description = "PostgreSQL username for Lakerunner"
   type        = string
@@ -132,7 +138,7 @@ variable "postgresql_password" {
 variable "postgresql_machine_type" {
   description = "PostgreSQL machine type"
   type        = string
-  default     = "db-f1-micro"
+  default     = "db-custom-1-3840"
 }
 
 variable "postgresql_disk_size_gb" {


### PR DESCRIPTION
## Summary
Bring `terraform/environments/poc/` more in line with how lakerunner is actually deployed (compared against `../lakerunner`, `../charts/lakerunner`, and `../terraform-deployments/google/production-428919/`).

- Add `pubsub_subscription_id` output — lakerunner reads `GCP_SUBSCRIPTION_ID` and the helm chart asks the operator for `pubsub.GCP.subscriptionID`; only the topic was previously exported.
- Make configdb name configurable via `postgresql_configdb_name`, default `"config"` to match `charts/lakerunner/values.yaml` defaults (was hardcoded `"configdb"`).
- Bump default `postgresql_machine_type` from `db-f1-micro` (legacy shared-core, deprecating) to `db-custom-1-3840`. Updated `terraform.tfvars.example` to match.
- `CLAUDE.md` Network Configuration section rewritten — `vpc_name` / `subnet_name` enterprise-mode language was stale (commit 625db57 made VPC creation unconditional).
- `terraform/environments/poc/README.md`: short note that maestro/conductor DB is not provisioned by this terraform.

## Test plan
- [x] `make fmt`
- [x] `make test` (terraform fmt + validate + plan against project_id `lakerunner-terraform`)
- [ ] Reviewer eyeballs the chart-default alignment for configdb name and pubsub output naming