### PR TITLE
Add aws-poc, drop Kafka and static credentials, rename poc to gcp-poc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,15 +9,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Purpose
 
-This repository provides Terraform infrastructure-as-code for deploying Lakerunner in GCP environments. It's designed primarily for customer POC (proof-of-concept) deployments, focusing on easy setup and excellent first impressions for potential customers evaluating the Lakerunner platform.
+This repository provides Terraform infrastructure-as-code for deploying Lakerunner in GCP, AWS, and Azure environments. It's designed primarily for customer POC (proof-of-concept) deployments, focusing on easy setup and excellent first impressions for potential customers evaluating the Lakerunner platform.
 
 ## Key Commands
 
 - `make` or `make help` - Show available commands
-- `make test` - Run full test suite (format check, validate, plan with test project)
-- `make fmt` - Auto-format all Terraform files
-- `make validate` - Validate Terraform configuration
-- `make plan` - Run terraform plan with test project ID `lakerunner-terraform`
+- `make test` - Run full test suite (format check, validate all envs, plan gcp-poc)
+- `make fmt` - Auto-format all Terraform files (recursive)
+- `make validate` - Validate all environments (no credentials needed)
+- `make plan` (alias `plan-gcp`) - Run terraform plan against gcp-poc with test project ID `lakerunner-terraform`
 - `make clean` - Clean up temporary Terraform files
 
 ## Architecture Overview
@@ -25,13 +25,15 @@ This repository provides Terraform infrastructure-as-code for deploying Lakerunn
 ### Directory Structure
 ```
 terraform/
-├── environments/poc/     # POC environment (primary focus)
-├── modules/gcp/          # Reusable GCP modules (future expansion)
-└── providers/gcp/        # GCP provider configuration
+├── environments/
+│   ├── gcp-poc/          # GCP POC environment
+│   ├── aws-poc/          # AWS POC environment
+│   └── azure-poc/        # Azure POC environment
+└── providers/{gcp,aws,azure}/ # Provider configuration snippets
 ```
 
 ### Multi-Cloud Design
-The structure is designed to support future AWS and Azure deployments, but currently focuses exclusively on GCP POC environments.
+Each `*-poc` environment is a self-contained Terraform root module. They share a common pattern: dedicated VPC, object storage with notification queue, optional managed Postgres (default on), managed Kubernetes cluster with workload identity (default on). Workload identity is the only auth path for the Lakerunner workload across all three clouds; no static credentials are emitted.
 
 ### Customer Configuration Strategy
 - `terraform.tfvars.example` - Template with documented options
@@ -40,38 +42,31 @@ The structure is designed to support future AWS and Azure deployments, but curre
 - Safe upgrade path: customer configs never conflict with repo updates
 
 ### Network Configuration
-The POC environment always provisions a dedicated VPC:
-- VPC + subnet `10.0.0.0/24` in the configured region
-- Secondary ranges for GKE pods (`10.4.0.0/14`) and services (`10.8.0.0/20`) added when `enable_gke = true`
-- Cloud Router + Cloud NAT for egress from private nodes
+Each POC environment always provisions a dedicated VPC. Specifics vary per cloud (subnet layout, secondary ranges for pods/services on GCP, AZ count for AWS) but all three follow the same pattern: dedicated VPC, NAT for egress, no peering to anything else.
 
 ### Core Infrastructure Components
 
-**Storage:**
-- `lakerunner` bucket - Main application bucket with Pub/Sub notifications
+**Storage and notifications (all clouds):**
+- One bucket per POC, with all object-create events routed to a queue (Pub/Sub on GCP, SQS on AWS, Storage Queue on Azure)
+- The Lakerunner consumer filters out the `db/` prefix; the cloud-side notification is unfiltered
 
-**Notifications:**
-- GCS → Pub/Sub integration for object create events
-- All notifications fire (GCS doesn't support path exclusions)
-- Application must filter out `db/` path notifications in subscriber
-
-**Kubernetes:**
-- Optional GKE cluster for container workloads (`enable_gke = false` by default)
-- Auto-scaling node pool (1-10 nodes) with spot instances for cost savings
-- Workload Identity enabled for secure service account mappings
+**Kubernetes (default on for all clouds):**
+- Managed cluster (GKE / EKS / AKS) with autoscaling node pool, Spot capacity by default
+- Workload identity (Workload Identity / IRSA / Workload Identity) wires a Kubernetes ServiceAccount to a cloud IAM identity scoped to the bucket and queue
+- This is the *only* auth path for the Lakerunner workload — no long-lived access keys are emitted
 
 **Security:**
-- Dedicated service accounts with least-privilege access
-- Auto-cleanup after 30 days for POC resources
-- No hardcoded credentials (uses GCP auth flow)
+- Dedicated service accounts / IAM roles with least-privilege access
+- Auto-cleanup after 30 days on the bucket
+- No hardcoded credentials anywhere
 
 ## Testing Strategy
 
-Tests run without requiring real GCP credentials by using:
-- Format validation (`terraform fmt -check`)
-- Configuration validation (`terraform validate`)
-- Targeted planning (`terraform plan -target=...`) with test project ID
-- Test project ID: `lakerunner-terraform` (safe, no real resources)
+Tests run without requiring real cloud credentials:
+- `terraform fmt -check -recursive` across the entire `terraform/` tree
+- `terraform validate` for each of the three environments (with `init -backend=false`)
+- Targeted `terraform plan` for gcp-poc only, using synthetic project ID `lakerunner-terraform`
+- AWS and Azure plans are not run by `make test` since they require real credentials
 
 ## Customer Experience Focus
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: help test check clean fmt validate plan
+.PHONY: help test check clean fmt validate plan plan-gcp
+
+ENVIRONMENTS := gcp-poc azure-poc aws-poc
 
 # Default target
 help: ## Show this help message
@@ -7,22 +9,26 @@ help: ## Show this help message
 	@echo "Available targets:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-test: ## Run all tests (format, validate, plan)
+test: ## Run all tests (format check + validate all envs + plan gcp-poc)
 	@./test.sh
 
 check: test ## Alias for test
 
-fmt: ## Format Terraform files
+fmt: ## Format Terraform files (recursive across all envs)
 	@echo "Formatting Terraform files..."
-	@cd terraform/environments/poc && terraform fmt -recursive
+	@cd terraform && terraform fmt -recursive
 
-validate: ## Validate Terraform configuration
-	@echo "Validating Terraform configuration..."
-	@cd terraform/environments/poc && terraform validate
+validate: ## Validate all environments (no credentials needed)
+	@for env in $(ENVIRONMENTS); do \
+		echo "==> Validating $$env"; \
+		(cd terraform/environments/$$env && terraform init -backend=false -input=false >/dev/null && terraform validate) || exit 1; \
+	done
 
-plan: ## Run terraform plan with test project ID
-	@echo "Running terraform plan..."
-	@cd terraform/environments/poc && terraform plan -var="project_id=lakerunner-terraform"
+plan: plan-gcp ## Alias for plan-gcp
+
+plan-gcp: ## Run terraform plan against gcp-poc with the test project ID
+	@echo "Running terraform plan against gcp-poc..."
+	@cd terraform/environments/gcp-poc && terraform plan -var="project_id=lakerunner-terraform"
 
 clean: ## Clean up temporary files
 	@echo "Cleaning up..."

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,8 +6,8 @@ Your `terraform.tfvars` files are automatically ignored by git, so you can safel
 
 ### Step 1: Backup Your Settings
 ```bash
-# Backup your current configuration
-cp terraform/environments/poc/terraform.tfvars terraform.tfvars.backup
+# Backup your current configuration (substitute your cloud below)
+cp terraform/environments/gcp-poc/terraform.tfvars terraform.tfvars.backup
 ```
 
 ### Step 2: Pull Updates
@@ -17,28 +17,50 @@ git pull origin main
 
 ### Step 3: Check for New Settings
 ```bash
-# Compare your settings with the latest example
-diff terraform/environments/poc/terraform.tfvars terraform/environments/poc/terraform.tfvars.example
+# Compare your settings with the latest example for your cloud
+diff terraform/environments/gcp-poc/terraform.tfvars terraform/environments/gcp-poc/terraform.tfvars.example
 ```
 
 ### Step 4: Apply Updates
 ```bash
-cd terraform/environments/poc
-terraform plan  # Review changes
-terraform apply  # Apply if everything looks good
+cd terraform/environments/gcp-poc   # or aws-poc / azure-poc
+terraform plan
+terraform apply
 ```
 
 ## What's Safe to Update
 
-**Always Safe**: We never modify your `terraform.tfvars` files  
-**Infrastructure Improvements**: New resources, better defaults  
-**Provider Updates**: Newer Terraform provider versions  
+**Always Safe**: We never modify your `terraform.tfvars` files
+**Infrastructure Improvements**: New resources, better defaults
+**Provider Updates**: Newer Terraform provider versions
 
 ## Configuration File Strategy
 
 - `terraform.tfvars.example` - Template with latest options (we may update this)
 - `terraform.tfvars` - Your custom settings (never tracked in git)
 - Your settings persist through all updates
+
+## Notable Past Changes
+
+### Directory Rename: `poc/` -> `gcp-poc/`
+
+The original GCP-only POC directory `terraform/environments/poc/` was renamed to `terraform/environments/gcp-poc/` when AWS and Azure POCs were added.
+
+If you have an existing local deployment, your `terraform.tfstate` lives inside the old directory and is not moved by the repo update. Either:
+
+```bash
+# Move your local state and tfvars into the new directory
+mv terraform/environments/poc/terraform.tfstate* terraform/environments/gcp-poc/
+mv terraform/environments/poc/terraform.tfvars terraform/environments/gcp-poc/
+mv terraform/environments/poc/.terraform terraform/environments/gcp-poc/ 2>/dev/null || true
+rmdir terraform/environments/poc
+```
+
+Or re-init from scratch in the new directory and `terraform import` your existing resources.
+
+### Removed: Kafka and Static Object-Store Credentials
+
+Older versions of this repo provisioned a managed Kafka cluster (gated by `enable_kafka`) and emitted S3-compatible HMAC keys (on GCP) or a Storage Account access key (on Azure). Both were removed; the workload now authenticates exclusively via Workload Identity / IRSA from the managed Kubernetes cluster. If you were using the static credentials, switch your workload to assume the role / service account emitted by the new outputs.
 
 ## Need Help?
 

--- a/docs/superpowers/specs/2026-05-04-aws-poc-design.md
+++ b/docs/superpowers/specs/2026-05-04-aws-poc-design.md
@@ -1,0 +1,283 @@
+# AWS POC + Cross-Cloud Cleanup Design
+
+Date: 2026-05-04
+
+## Goal
+
+Add an `aws-poc` Terraform environment that mirrors the existing GCP and Azure
+POC patterns, while simultaneously simplifying all three POCs by removing
+Kafka and removing static workload credentials in favor of federated identity
+from a managed Kubernetes cluster.
+
+## In scope
+
+1. **New environment**: `terraform/environments/aws-poc/`
+2. **Rename**: `terraform/environments/poc/` → `terraform/environments/gcp-poc/`
+3. **Update path references**: `Makefile`, `test.sh`, `CLAUDE.md`, `UPGRADE.md`,
+   and the inner `README.md`
+4. **Remove Kafka entirely** from `gcp-poc` (Managed Kafka cluster, topics,
+   IAM bindings, `enable_kafka` and `kafka_*` variables, Kafka outputs) and
+   from `azure-poc` (Event Hubs namespace, `enable_kafka` and `eventhub_*`
+   variables, Kafka outputs)
+5. **Remove static credentials**: `google_storage_hmac_key.lakerunner_s3_key`
+   and `s3_access_key/secret/endpoint/region` outputs from `gcp-poc`;
+   `storage_account_access_key` output from `azure-poc`
+6. **Default-on managed Kubernetes** in all three POCs:
+   `enable_eks/gke/aks = true`. Workload identity is the only auth path.
+
+## Out of scope
+
+- Multi-region or multi-AZ-active deployments (POC is single region, RDS is
+  single-AZ).
+- VPC endpoints, transit gateways, or any of the heavier prod-style AWS
+  networking.
+- A shared `modules/` library. Each POC remains a self-contained root module,
+  matching today's convention.
+- Pulling resources out of `gcp-poc` / `azure-poc` beyond the Kafka and
+  static-credential removals listed above.
+- Migration tooling for any existing `poc/` deployment's local tfstate.
+  Existing deployers `mv` their state directory or re-init by hand.
+- Backwards-compatibility shims (no aliasing of removed variables, no
+  deprecation warnings).
+
+## Directory layout after the change
+
+```
+terraform/
+├── environments/
+│   ├── gcp-poc/    (renamed from poc/, Kafka and HMAC keys removed,
+│   │                enable_gke = true by default)
+│   ├── azure-poc/  (Event Hubs and access-key output removed,
+│   │                enable_aks = true by default)
+│   └── aws-poc/    (NEW)
+├── modules/
+│   ├── gcp/
+│   ├── azure/      (NEW empty placeholder for symmetry)
+│   └── aws/        (NEW empty placeholder for symmetry)
+└── providers/
+    ├── gcp/
+    ├── azure/
+    └── aws/        (NEW)
+```
+
+## AWS POC components
+
+### Storage and eventing
+
+Mirrors the production `aws/production/us-east-2/cardinalhq-bucket-sqs.tf`
+pattern.
+
+- `aws_s3_bucket` named `lr-${installation_id}-lakerunner-${random_hex}`.
+  Versioning off, force-destroy on, public access blocked, TLS-only bucket
+  policy, 30-day lifecycle expiration on all objects (matches GCP POC's
+  bucket lifecycle).
+- `aws_sqs_queue` named `lr-${installation_id}-notifications-${random_hex}`,
+  SSE managed by SQS, default retention.
+- `aws_sqs_queue_policy` allowing `s3.amazonaws.com` to `SendMessage`,
+  scoped by `aws:SourceAccount` (current account) and `aws:SourceArn` of
+  the bucket.
+- `aws_s3_bucket_notification` sending `s3:ObjectCreated:*` to the queue.
+  No path filter; the consumer filters out `db/` (parity with GCP POC).
+- `aws_s3_bucket_public_access_block` with all four flags `true`.
+
+### Networking
+
+- `aws_vpc` with CIDR `10.0.0.0/16`.
+- 2 public subnets (`10.0.0.0/24`, `10.0.1.0/24`) and 2 private subnets
+  (`10.0.10.0/24`, `10.0.11.0/24`) across the first two AZs from
+  `data.aws_availability_zones.available`.
+- `aws_internet_gateway` and a single `aws_nat_gateway` in one public
+  subnet (cost-conscious POC default).
+- Route tables wiring private subnets through NAT to the IGW.
+- Security groups: one for EKS nodes (allow all egress, intra-SG ingress),
+  one for RDS (5432 from inside the VPC).
+- No VPC endpoints (POC simplification).
+
+### Compute (EKS, default on)
+
+- `aws_eks_cluster` named `lr-${installation_id}-eks` on the private subnets,
+  public endpoint enabled.
+- `aws_iam_openid_connect_provider` for the cluster's OIDC issuer (required
+  for IRSA).
+- One `aws_eks_node_group` with autoscaling 1-10 (matches GCP defaults),
+  instance types `["t3.large"]`, capacity type `SPOT` by default, 50 GB
+  gp3 disks, on the private subnets.
+- IAM roles for the cluster control plane and the node group with the AWS
+  managed policies (`AmazonEKSClusterPolicy`, `AmazonEKSWorkerNodePolicy`,
+  `AmazonEKS_CNI_Policy`, `AmazonEC2ContainerRegistryReadOnly`).
+
+### Workload identity (IRSA)
+
+- `aws_iam_role` for the Lakerunner workload, trust policy bound to the
+  cluster's OIDC issuer for ServiceAccount `lakerunner/lakerunner`.
+- Inline IAM policy granting:
+  - `s3:GetObject`, `PutObject`, `DeleteObject`, `ListBucket`,
+    `GetBucketLocation` on the bucket and its objects.
+  - `sqs:ReceiveMessage`, `DeleteMessage`, `GetQueueAttributes`,
+    `GetQueueUrl` on the queue.
+- Output: role ARN and a `kubectl annotate serviceaccount lakerunner
+  eks.amazonaws.com/role-arn=...` command (mirrors GCP's annotation
+  command output).
+
+### Database (RDS Postgres, default on)
+
+- `aws_db_subnet_group` across the two private subnets.
+- `aws_db_instance` running Postgres 17 on `db.t4g.medium`, 20 GB gp3,
+  single-AZ, 7-day automated backups, deletion protection off.
+- Security group permitting 5432 from inside the VPC.
+- Database initialization (creating the `lakerunner` and `config`
+  databases) uses the `cyrilgdn/postgresql` provider after the instance
+  is up. This mirrors the GCP POC's two-database pattern on a single
+  instance.
+- Auto-generated password via `random_password` when
+  `var.postgresql_password` is empty.
+
+### Tagging
+
+- `aws` provider configured with `default_tags` from a `local.common_tags`
+  map containing `lakerunner-id`, `environment`, `managed-by=terraform`,
+  merged with `var.tags`.
+
+## Variables
+
+| Variable | Type | Default | Notes |
+|---|---|---|---|
+| `installation_id` | string | `"poc"` | 3-10 chars, regex-validated like GCP |
+| `region` | string | `"us-east-2"` | matches prod region |
+| `environment` | string | `"poc"` | |
+| `tags` | map(string) | `{}` | |
+| `vpc_cidr` | string | `"10.0.0.0/16"` | |
+| `create_postgresql` | bool | `true` | |
+| `postgresql_instance_class` | string | `"db.t4g.medium"` | |
+| `postgresql_allocated_storage` | number | `20` | GB |
+| `postgresql_engine_version` | string | `"17"` | |
+| `postgresql_database_name` | string | `"lakerunner"` | |
+| `postgresql_configdb_name` | string | `"config"` | |
+| `postgresql_username` | string | `"lakerunner"` | |
+| `postgresql_password` | string (sensitive) | `""` | auto-generated when empty |
+| `enable_eks` | bool | `true` | |
+| `eks_kubernetes_version` | string | `"1.31"` | |
+| `eks_node_min` | number | `1` | |
+| `eks_node_max` | number | `10` | |
+| `eks_node_instance_types` | list(string) | `["t3.large"]` | |
+| `eks_node_use_spot` | bool | `true` | |
+| `eks_node_disk_size` | number | `50` | GB |
+
+## Outputs
+
+- Storage / eventing: `lakerunner_bucket`, `lakerunner_bucket_arn`,
+  `sqs_queue_name`, `sqs_queue_url`, `sqs_queue_arn`.
+- Network: `vpc_id`, `vpc_cidr`, `private_subnet_ids`, `public_subnet_ids`.
+- Identity: `lakerunner_role_arn`,
+  `service_account_annotation_command`.
+- EKS: `eks_cluster_name`, `eks_cluster_endpoint` (sensitive),
+  `eks_oidc_provider_arn`, `kubectl_command`.
+- Postgres: `postgresql_endpoint`, `postgresql_port`,
+  `postgresql_database_name`, `postgresql_configdb_name`,
+  `postgresql_user`, `postgresql_password` (sensitive),
+  `postgresql_connection_string` (sensitive).
+- Environment: `region`, `account_id`.
+- `deployment_summary` heredoc mirroring the GCP POC's, sized to the
+  resources actually present.
+
+## Provider configuration
+
+In `terraform/providers/aws/`:
+
+- `versions.tf` declaring `aws ~> 5.0`, `random ~> 3.0`,
+  `kubernetes ~> 2.0`, `cyrilgdn/postgresql ~> 1.22`.
+- `provider.tf` configuring the `aws` provider with `default_tags`.
+
+The root `aws-poc/main.tf` uses these providers directly. The
+`kubernetes` and `postgresql` providers are configured from EKS / RDS
+outputs and are only meaningfully exercised when those resources exist.
+
+## Cross-cutting changes to existing POCs
+
+### `gcp-poc` (after rename)
+
+Remove:
+- `google_storage_hmac_key.lakerunner_s3_key` resource.
+- `s3_access_key`, `s3_secret_key`, `s3_endpoint`, `s3_region` outputs.
+- `google_managed_kafka_cluster`, `google_managed_kafka_topic`,
+  `google_project_iam_member.lakerunner_kafka_admin`, and
+  `google_project_service.managed_kafka_api` resources.
+- `enable_kafka`, `kafka_cpu_count`, `kafka_memory_gb` variables.
+- `kafka_cluster_id`, `kafka_cluster_name`, `kafka_topics`,
+  `kafka_connection_info` outputs.
+- The S3-compatible and Kafka sections from `deployment_summary`.
+
+Change:
+- `enable_gke` default from `false` to `true`.
+
+### `azure-poc`
+
+Remove:
+- `azurerm_eventhub_namespace.ehns` resource.
+- `enable_kafka`, `eventhub_sku`, `eventhub_capacity` variables.
+- `kafka_bootstrap_server` output.
+- `storage_account_access_key` output.
+
+Change:
+- `enable_aks` default from `false` to `true`.
+
+### Repository plumbing
+
+- `Makefile`:
+  - `fmt`: run `terraform fmt -recursive` once at `terraform/` root
+    so all three environments (and any future modules) are formatted
+    in one pass.
+  - `validate`: loop over each `terraform/environments/*/` directory and
+    run `terraform init -backend=false && terraform validate`. AWS and
+    Azure both validate without real credentials.
+  - `plan`: stays GCP-specific. The current `-var="project_id=..."`
+    seeding only works for GCP, and AWS / Azure plans need real
+    credentials anyway. Renamed to `plan-gcp` and the `plan` target
+    becomes an alias for `plan-gcp`.
+- `test.sh`: rewritten to:
+  1. `terraform fmt -check -recursive` once at `terraform/` root.
+  2. `terraform init -backend=false && terraform validate` in each of
+     the three environments.
+  3. `terraform plan -var="project_id=lakerunner-terraform"
+     -target=google_storage_bucket.lakerunner` in `gcp-poc` only,
+     matching today's behavior.
+- `CLAUDE.md`: update the "Architecture Overview" and "Key Commands"
+  sections to reflect the renamed `gcp-poc/` directory and the AWS
+  addition.
+- `UPGRADE.md`: add a note about the `poc/` → `gcp-poc/` rename and what
+  existing deployers need to do (move local state, re-init).
+- `terraform/environments/gcp-poc/README.md`: update path references and
+  drop the Kafka and S3-compatibility sections.
+
+## Testing strategy
+
+Per existing pattern, tests run without requiring real cloud credentials:
+
+- `terraform fmt -check` recursively across all three environments.
+- `terraform validate` for each of the three environments. (AWS validate
+  works without credentials.)
+- `terraform plan` for `gcp-poc` only, using the synthetic project ID
+  `lakerunner-terraform`, matching today's behavior.
+
+A separate manual smoke test (real `terraform apply` in a sandbox AWS
+account) is expected before merge. Not automated.
+
+## Risks and trade-offs
+
+- **Local state migration on rename**: a `git mv environments/poc
+  environments/gcp-poc` does not move any deployer's local tfstate
+  outside this repo. Existing deployers will see a fresh-init prompt at
+  the new path unless they manually move their state. Documented in
+  `UPGRADE.md`; not automated.
+- **EKS-on-by-default cost**: a default `terraform apply` against the AWS
+  POC now stands up an EKS control plane (~$73/mo) plus 1+ Spot t3.large
+  nodes (~$15-30/mo) plus an RDS t4g.medium (~$25/mo) plus a NAT Gateway
+  (~$33/mo + data). This is a real meter-running cost. The 30-day bucket
+  lifecycle and "POC" framing partially mitigate, but documented clearly
+  in the AWS POC README so demoing customers know.
+- **Single NAT, single-AZ RDS**: explicit cost-vs-resilience trade made
+  for POC. Not appropriate for prod.
+- **`db/` consumer-side filter**: the AWS POC, like the GCP POC, sends
+  every `s3:ObjectCreated:*` event to SQS and relies on the Lakerunner
+  consumer to drop `db/` traffic. Documented inline in the
+  `aws_s3_bucket_notification` resource.

--- a/terraform/environments/aws-poc/README.md
+++ b/terraform/environments/aws-poc/README.md
@@ -1,0 +1,82 @@
+# Lakerunner POC Environment - AWS
+
+This Terraform configuration creates a minimal AWS environment for evaluating Lakerunner.
+
+For GCP see `../gcp-poc/`. For Azure see `../azure-poc/`.
+
+## Quick Start
+
+### Prerequisites
+
+- AWS account with admin (or equivalent) permissions
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) (v1.3+)
+- [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) configured (`aws configure` or `aws sso login`)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+
+### Setup Steps
+
+1. **Configure your deployment**
+   ```bash
+   cd terraform/environments/aws-poc/
+   cp terraform.tfvars.example terraform.tfvars
+   # edit terraform.tfvars - region, installation_id, optionally tighten postgresql_allowed_cidr
+   ```
+
+2. **Deploy**
+   ```bash
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+
+   Expect ~15-20 minutes (EKS control plane is the long pole).
+
+3. **Connect to the cluster**
+   ```bash
+   eval "$(terraform output -raw kubectl_command)"
+   kubectl get nodes
+   ```
+
+4. **Annotate the Lakerunner ServiceAccount with the IRSA role**
+   ```bash
+   kubectl create namespace lakerunner
+   kubectl create serviceaccount lakerunner -n lakerunner
+   eval "$(terraform output -raw service_account_annotation_command)"
+   ```
+
+   The Lakerunner Helm chart can then run as ServiceAccount `lakerunner/lakerunner` and pick up the IAM role automatically via IRSA.
+
+## What Gets Created
+
+- **VPC** with two public + two private subnets across two AZs, single NAT Gateway
+- **S3 bucket** for telemetry data, with all `s3:ObjectCreated:*` events routed to:
+- **SQS queue** consumed by Lakerunner. The consumer filters out the `db/` prefix (parity with the GCP POC).
+- **EKS cluster** with one managed node group (Spot by default, autoscaling 1-10)
+- **OIDC provider** + **IAM role** for IRSA, scoped to ServiceAccount `lakerunner/lakerunner`, with permissions on the bucket and the queue
+- **RDS Postgres** (publicly accessible for POC ease) with two databases: `lakerunner` and `config`
+
+## Cost Notes
+
+A default `terraform apply` is meter-running. Approximate monthly idle cost in `us-east-2`:
+
+- EKS control plane: ~$73
+- 1x t3.large Spot node: ~$15
+- NAT Gateway: ~$33 + data
+- RDS db.t4g.medium single-AZ: ~$25
+- S3, SQS, IPs: low single digits
+
+Disable EKS or Postgres via the `enable_eks` / `create_postgresql` variables to skip those.
+
+## Cleanup
+
+```bash
+terraform destroy
+```
+
+Note: an `aws_eip` may take a moment to release. The S3 bucket has `force_destroy = true` so non-empty buckets will still be destroyed.
+
+## Out of Scope
+
+- Multi-AZ RDS, HA control plane, custom KMS keys, VPC endpoints
+- IAM users with static access keys (workload auth is IRSA only)
+- Kafka / MSK

--- a/terraform/environments/aws-poc/eks.tf
+++ b/terraform/environments/aws-poc/eks.tf
@@ -1,0 +1,127 @@
+######################################
+# EKS cluster + node group + OIDC provider for IRSA
+######################################
+resource "aws_iam_role" "eks_cluster" {
+  count = var.enable_eks ? 1 : 0
+  name  = "${local.name_prefix}-eks-cluster-${random_id.suffix.hex}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "eks.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
+  count      = var.enable_eks ? 1 : 0
+  role       = aws_iam_role.eks_cluster[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+resource "aws_security_group" "eks_cluster" {
+  count       = var.enable_eks ? 1 : 0
+  name_prefix = "${local.name_prefix}-eks-cluster-"
+  description = "EKS control plane SG"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_eks_cluster" "main" {
+  count    = var.enable_eks ? 1 : 0
+  name     = "${local.name_prefix}-eks"
+  role_arn = aws_iam_role.eks_cluster[0].arn
+  version  = var.eks_kubernetes_version
+
+  vpc_config {
+    subnet_ids              = concat(aws_subnet.private[*].id, aws_subnet.public[*].id)
+    endpoint_private_access = true
+    endpoint_public_access  = true
+    security_group_ids      = [aws_security_group.eks_cluster[0].id]
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.eks_cluster_policy]
+}
+
+data "tls_certificate" "eks_oidc" {
+  count = var.enable_eks ? 1 : 0
+  url   = aws_eks_cluster.main[0].identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_openid_connect_provider" "eks" {
+  count           = var.enable_eks ? 1 : 0
+  url             = aws_eks_cluster.main[0].identity[0].oidc[0].issuer
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.eks_oidc[0].certificates[0].sha1_fingerprint]
+}
+
+######################################
+# Node group
+######################################
+resource "aws_iam_role" "eks_node" {
+  count = var.enable_eks ? 1 : 0
+  name  = "${local.name_prefix}-eks-node-${random_id.suffix.hex}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "eks_node_worker" {
+  count      = var.enable_eks ? 1 : 0
+  role       = aws_iam_role.eks_node[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "eks_node_cni" {
+  count      = var.enable_eks ? 1 : 0
+  role       = aws_iam_role.eks_node[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "eks_node_ecr" {
+  count      = var.enable_eks ? 1 : 0
+  role       = aws_iam_role.eks_node[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_eks_node_group" "main" {
+  count           = var.enable_eks ? 1 : 0
+  cluster_name    = aws_eks_cluster.main[0].name
+  node_group_name = "lakerunner"
+  node_role_arn   = aws_iam_role.eks_node[0].arn
+  subnet_ids      = aws_subnet.private[*].id
+
+  capacity_type  = var.eks_node_use_spot ? "SPOT" : "ON_DEMAND"
+  instance_types = var.eks_node_instance_types
+  disk_size      = var.eks_node_disk_size
+
+  scaling_config {
+    desired_size = var.eks_node_min
+    min_size     = var.eks_node_min
+    max_size     = var.eks_node_max
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_node_worker,
+    aws_iam_role_policy_attachment.eks_node_cni,
+    aws_iam_role_policy_attachment.eks_node_ecr,
+  ]
+}

--- a/terraform/environments/aws-poc/iam.tf
+++ b/terraform/environments/aws-poc/iam.tf
@@ -1,0 +1,77 @@
+######################################
+# IRSA: IAM role assumed by the lakerunner ServiceAccount via the
+# cluster's OIDC provider. Created only when EKS is enabled, since
+# the trust policy depends on the cluster's OIDC issuer.
+######################################
+locals {
+  oidc_issuer_host = var.enable_eks ? replace(aws_iam_openid_connect_provider.eks[0].url, "https://", "") : ""
+}
+
+data "aws_iam_policy_document" "lakerunner_trust" {
+  count = var.enable_eks ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.eks[0].arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_issuer_host}:sub"
+      values   = ["system:serviceaccount:lakerunner:lakerunner"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_issuer_host}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lakerunner" {
+  count              = var.enable_eks ? 1 : 0
+  name               = "${local.name_prefix}-lakerunner-${random_id.suffix.hex}"
+  assume_role_policy = data.aws_iam_policy_document.lakerunner_trust[0].json
+}
+
+data "aws_iam_policy_document" "lakerunner_inline" {
+  statement {
+    sid    = "LakerunnerBucket"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+    resources = [
+      aws_s3_bucket.lakerunner.arn,
+      "${aws_s3_bucket.lakerunner.arn}/*",
+    ]
+  }
+
+  statement {
+    sid    = "LakerunnerQueue"
+    effect = "Allow"
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl",
+    ]
+    resources = [aws_sqs_queue.notifications.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "lakerunner" {
+  count  = var.enable_eks ? 1 : 0
+  name   = "lakerunner-bucket-and-queue"
+  role   = aws_iam_role.lakerunner[0].id
+  policy = data.aws_iam_policy_document.lakerunner_inline.json
+}

--- a/terraform/environments/aws-poc/main.tf
+++ b/terraform/environments/aws-poc/main.tf
@@ -1,0 +1,248 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+      version = "~> 1.22"
+    }
+  }
+}
+
+locals {
+  common_tags = merge(var.tags, {
+    "lakerunner-id" = var.installation_id
+    "environment"   = var.environment
+    "managed-by"    = "terraform"
+  })
+
+  name_prefix = "lr-${var.installation_id}"
+
+  postgresql_password = var.create_postgresql && var.postgresql_password == "" ? random_password.postgresql[0].result : var.postgresql_password
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+resource "random_password" "postgresql" {
+  count   = var.create_postgresql && var.postgresql_password == "" ? 1 : 0
+  length  = 16
+  special = false
+}
+
+######################################
+# Networking
+######################################
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${local.name_prefix}-vpc-${random_id.suffix.hex}"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name_prefix}-igw-${random_id.suffix.hex}"
+  }
+}
+
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name                     = "${local.name_prefix}-public-${count.index}-${random_id.suffix.hex}"
+    "kubernetes.io/role/elb" = "1"
+  }
+}
+
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 10)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name                              = "${local.name_prefix}-private-${count.index}-${random_id.suffix.hex}"
+    "kubernetes.io/role/internal-elb" = "1"
+  }
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = {
+    Name = "${local.name_prefix}-nat-eip-${random_id.suffix.hex}"
+  }
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = {
+    Name = "${local.name_prefix}-nat-${random_id.suffix.hex}"
+  }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-public-rt-${random_id.suffix.hex}"
+  }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-private-rt-${random_id.suffix.hex}"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(aws_subnet.private)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+######################################
+# S3 bucket + SQS notification queue
+######################################
+resource "aws_s3_bucket" "lakerunner" {
+  bucket        = "${local.name_prefix}-lakerunner-${random_id.suffix.hex}"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "lakerunner" {
+  bucket                  = aws_s3_bucket.lakerunner.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "lakerunner" {
+  bucket = aws_s3_bucket.lakerunner.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.lakerunner.arn,
+          "${aws_s3_bucket.lakerunner.arn}/*",
+        ]
+        Condition = {
+          Bool = { "aws:SecureTransport" = "false" }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "lakerunner" {
+  bucket = aws_s3_bucket.lakerunner.id
+
+  rule {
+    id     = "poc-expire-30d"
+    status = "Enabled"
+    filter {}
+    expiration {
+      days = 30
+    }
+  }
+}
+
+resource "aws_sqs_queue" "notifications" {
+  name                    = "${local.name_prefix}-notifications-${random_id.suffix.hex}"
+  sqs_managed_sse_enabled = true
+}
+
+resource "aws_sqs_queue_policy" "notifications" {
+  queue_url = aws_sqs_queue.notifications.url
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "s3.amazonaws.com" }
+        Action    = "sqs:SendMessage"
+        Resource  = aws_sqs_queue.notifications.arn
+        Condition = {
+          ArnEquals    = { "aws:SourceArn" = aws_s3_bucket.lakerunner.arn }
+          StringEquals = { "aws:SourceAccount" = data.aws_caller_identity.current.account_id }
+        }
+      }
+    ]
+  })
+}
+
+# All ObjectCreated events go to the queue. The Lakerunner consumer filters
+# out the db/ path, matching the GCP POC's behavior.
+resource "aws_s3_bucket_notification" "lakerunner" {
+  bucket = aws_s3_bucket.lakerunner.id
+
+  queue {
+    queue_arn = aws_sqs_queue.notifications.arn
+    events    = ["s3:ObjectCreated:*"]
+  }
+
+  depends_on = [aws_sqs_queue_policy.notifications]
+}

--- a/terraform/environments/aws-poc/outputs.tf
+++ b/terraform/environments/aws-poc/outputs.tf
@@ -1,0 +1,132 @@
+##############
+# Storage / eventing
+##############
+output "lakerunner_bucket" {
+  description = "S3 bucket name receiving Lakerunner data"
+  value       = aws_s3_bucket.lakerunner.bucket
+}
+
+output "lakerunner_bucket_arn" {
+  description = "S3 bucket ARN"
+  value       = aws_s3_bucket.lakerunner.arn
+}
+
+output "sqs_queue_name" {
+  description = "SQS queue receiving s3:ObjectCreated:* events"
+  value       = aws_sqs_queue.notifications.name
+}
+
+output "sqs_queue_url" {
+  description = "SQS queue URL"
+  value       = aws_sqs_queue.notifications.url
+}
+
+output "sqs_queue_arn" {
+  description = "SQS queue ARN"
+  value       = aws_sqs_queue.notifications.arn
+}
+
+##############
+# Network
+##############
+output "vpc_id" { value = aws_vpc.main.id }
+output "vpc_cidr" { value = aws_vpc.main.cidr_block }
+output "private_subnet_ids" { value = aws_subnet.private[*].id }
+output "public_subnet_ids" { value = aws_subnet.public[*].id }
+
+##############
+# Identity (IRSA)
+##############
+output "lakerunner_role_arn" {
+  description = "IAM role ARN to be assumed by the lakerunner ServiceAccount via IRSA"
+  value       = var.enable_eks ? aws_iam_role.lakerunner[0].arn : null
+}
+
+output "service_account_annotation_command" {
+  description = "kubectl command to wire the lakerunner ServiceAccount to the IAM role"
+  value       = var.enable_eks ? "kubectl annotate serviceaccount lakerunner eks.amazonaws.com/role-arn=${aws_iam_role.lakerunner[0].arn} -n lakerunner" : null
+}
+
+##############
+# EKS
+##############
+output "eks_cluster_name" {
+  description = "EKS cluster name"
+  value       = var.enable_eks ? aws_eks_cluster.main[0].name : null
+}
+
+output "eks_cluster_endpoint" {
+  description = "EKS API endpoint"
+  value       = var.enable_eks ? aws_eks_cluster.main[0].endpoint : null
+  sensitive   = true
+}
+
+output "eks_oidc_provider_arn" {
+  description = "OIDC provider ARN for IRSA"
+  value       = var.enable_eks ? aws_iam_openid_connect_provider.eks[0].arn : null
+}
+
+output "kubectl_command" {
+  description = "Command to configure kubectl"
+  value       = var.enable_eks ? "aws eks update-kubeconfig --name=${aws_eks_cluster.main[0].name} --region=${var.region}" : null
+}
+
+##############
+# Postgres
+##############
+output "postgresql_endpoint" {
+  description = "RDS instance endpoint"
+  value       = var.create_postgresql ? aws_db_instance.main[0].address : null
+}
+
+output "postgresql_port" {
+  description = "RDS instance port"
+  value       = var.create_postgresql ? aws_db_instance.main[0].port : null
+}
+
+output "postgresql_database_name" {
+  value = var.postgresql_database_name
+}
+
+output "postgresql_configdb_name" {
+  value = var.postgresql_configdb_name
+}
+
+output "postgresql_user" {
+  value = var.postgresql_username
+}
+
+output "postgresql_password" {
+  value     = local.postgresql_password
+  sensitive = true
+}
+
+output "postgresql_connection_string" {
+  description = "Postgres connection string (sslmode=require)"
+  value       = var.create_postgresql ? "postgresql://${var.postgresql_username}:${local.postgresql_password}@${aws_db_instance.main[0].address}:${aws_db_instance.main[0].port}/${var.postgresql_database_name}?sslmode=require" : null
+  sensitive   = true
+}
+
+##############
+# Environment
+##############
+output "region" { value = var.region }
+output "account_id" { value = data.aws_caller_identity.current.account_id }
+
+output "deployment_summary" {
+  description = "POC deployment summary"
+  value       = <<-EOT
+    Storage:
+      Lakerunner Bucket: ${aws_s3_bucket.lakerunner.bucket}
+      SQS Queue: ${aws_sqs_queue.notifications.name}
+      SQS URL: ${aws_sqs_queue.notifications.url}
+      ${var.create_postgresql ? "Database:\n      RDS Endpoint: ${aws_db_instance.main[0].address}:${aws_db_instance.main[0].port}\n      Databases: ${var.postgresql_database_name}, ${var.postgresql_configdb_name}\n      User: ${var.postgresql_username}\n      Password: [SENSITIVE - 'terraform output -raw postgresql_password']" : "Enable Postgres with create_postgresql=true for database support"}
+
+    Network:
+      VPC: ${aws_vpc.main.id} (${aws_vpc.main.cidr_block})
+      Public subnets: ${join(", ", aws_subnet.public[*].id)}
+      Private subnets: ${join(", ", aws_subnet.private[*].id)}
+
+    ${var.enable_eks ? "Kubernetes:\n      EKS Cluster: ${aws_eks_cluster.main[0].name}\n      Nodes: ${var.eks_node_min}-${var.eks_node_max} ${join(",", var.eks_node_instance_types)} (${var.eks_node_use_spot ? "SPOT" : "ON_DEMAND"})\n      kubectl: aws eks update-kubeconfig --name=${aws_eks_cluster.main[0].name} --region=${var.region}\n\n    Identity (IRSA):\n      Role ARN: ${aws_iam_role.lakerunner[0].arn}\n      Annotate SA: kubectl annotate serviceaccount lakerunner eks.amazonaws.com/role-arn=${aws_iam_role.lakerunner[0].arn} -n lakerunner" : "Enable EKS with enable_eks=true for container workloads"}
+  EOT
+}

--- a/terraform/environments/aws-poc/rds.tf
+++ b/terraform/environments/aws-poc/rds.tf
@@ -1,0 +1,84 @@
+######################################
+# RDS Postgres + lakerunner/config databases
+#
+# RDS is publicly accessible for the POC so terraform can create the second
+# database via the postgresql provider, and so operators can connect from
+# their workstation for ad-hoc inspection. The security group restricts
+# inbound 5432 to var.postgresql_allowed_cidr (default 0.0.0.0/0).
+# Tighten that variable for any non-throwaway deployment.
+######################################
+resource "aws_db_subnet_group" "main" {
+  count      = var.create_postgresql ? 1 : 0
+  name       = "${local.name_prefix}-db-${random_id.suffix.hex}"
+  subnet_ids = aws_subnet.public[*].id
+}
+
+resource "aws_security_group" "rds" {
+  count       = var.create_postgresql ? 1 : 0
+  name_prefix = "${local.name_prefix}-rds-"
+  description = "Lakerunner POC Postgres"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "Postgres from inside the VPC"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  ingress {
+    description = "Postgres from configured external CIDRs"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = var.postgresql_allowed_cidr
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_db_instance" "main" {
+  count                      = var.create_postgresql ? 1 : 0
+  identifier                 = "${local.name_prefix}-pg-${random_id.suffix.hex}"
+  engine                     = "postgres"
+  engine_version             = var.postgresql_engine_version
+  instance_class             = var.postgresql_instance_class
+  allocated_storage          = var.postgresql_allocated_storage
+  storage_type               = "gp3"
+  db_name                    = var.postgresql_database_name
+  username                   = var.postgresql_username
+  password                   = local.postgresql_password
+  db_subnet_group_name       = aws_db_subnet_group.main[0].name
+  vpc_security_group_ids     = [aws_security_group.rds[0].id]
+  publicly_accessible        = true
+  skip_final_snapshot        = true
+  deletion_protection        = false
+  backup_retention_period    = 7
+  auto_minor_version_upgrade = true
+  apply_immediately          = true
+}
+
+provider "postgresql" {
+  host            = var.create_postgresql ? aws_db_instance.main[0].address : ""
+  port            = var.create_postgresql ? aws_db_instance.main[0].port : 5432
+  database        = var.postgresql_database_name
+  username        = var.postgresql_username
+  password        = local.postgresql_password
+  sslmode         = "require"
+  superuser       = false
+  connect_timeout = 30
+}
+
+resource "postgresql_database" "configdb" {
+  count = var.create_postgresql ? 1 : 0
+  name  = var.postgresql_configdb_name
+  owner = var.postgresql_username
+
+  depends_on = [aws_db_instance.main]
+}

--- a/terraform/environments/aws-poc/terraform.tfvars.example
+++ b/terraform/environments/aws-poc/terraform.tfvars.example
@@ -1,0 +1,49 @@
+# =============================================================================
+# LAKERUNNER POC ENVIRONMENT - AWS - QUICK SETUP
+# =============================================================================
+# This creates a minimal AWS environment for evaluating Lakerunner.
+# Perfect for demos, trials, and proof-of-concept deployments.
+
+# REQUIRED: AWS region
+region = "us-east-2"
+
+# OPTIONAL: Installation ID for multiple POCs in the same account
+# 3-10 chars, must start with a letter, lowercase + digits only
+installation_id = "poc"
+
+# Environment identifier
+environment = "poc"
+
+# Tags applied to all resources
+tags = {
+  # team        = "your-team-name"
+  # cost_center = "engineering"
+}
+
+# Network Configuration
+# A dedicated VPC is created for the POC. Adjust the CIDR if needed.
+vpc_cidr = "10.0.0.0/16"
+
+# Kubernetes Options
+# EKS is on by default. Workload Identity (IRSA) is the only auth path
+# for the Lakerunner workload, so disabling this means you must bring
+# your own cluster and wire IAM-to-ServiceAccount mapping yourself.
+enable_eks              = true
+eks_kubernetes_version  = "1.31"
+eks_node_min            = 1
+eks_node_max            = 10
+eks_node_instance_types = ["t3.large"]
+eks_node_use_spot       = true
+eks_node_disk_size      = 50
+
+# PostgreSQL Configuration
+create_postgresql            = true
+postgresql_instance_class    = "db.t4g.medium"
+postgresql_allocated_storage = 20
+postgresql_engine_version    = "17"
+
+# Leave postgresql_password empty for auto-generation.
+# postgresql_password = ""
+
+# RDS is publicly accessible for POC ease. Tighten this for any real use.
+postgresql_allowed_cidr = ["0.0.0.0/0"]

--- a/terraform/environments/aws-poc/variables.tf
+++ b/terraform/environments/aws-poc/variables.tf
@@ -1,0 +1,143 @@
+#####################
+# Environment & naming
+#####################
+variable "installation_id" {
+  description = "Unique identifier for this installation (3-10 chars, lowercase + digits, must start with a letter)"
+  type        = string
+  default     = "poc"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9]{2,9}$", var.installation_id))
+    error_message = "Installation ID must be 3-10 characters, start with a letter, then letters and numbers only."
+  }
+}
+
+variable "region" {
+  description = "AWS region for POC resources"
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "environment" {
+  description = "Environment identifier"
+  type        = string
+  default     = "poc"
+}
+
+variable "tags" {
+  description = "Additional tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+#####################
+# Networking
+#####################
+variable "vpc_cidr" {
+  description = "CIDR block for the dedicated POC VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+#####################
+# PostgreSQL (RDS)
+#####################
+variable "create_postgresql" {
+  description = "Create an RDS Postgres instance for Lakerunner"
+  type        = bool
+  default     = true
+}
+
+variable "postgresql_engine_version" {
+  description = "Postgres engine major version"
+  type        = string
+  default     = "17"
+}
+
+variable "postgresql_instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t4g.medium"
+}
+
+variable "postgresql_allocated_storage" {
+  description = "Allocated storage (GB) for the RDS instance"
+  type        = number
+  default     = 20
+}
+
+variable "postgresql_database_name" {
+  description = "Initial database name (created by RDS itself)"
+  type        = string
+  default     = "lakerunner"
+}
+
+variable "postgresql_configdb_name" {
+  description = "Second database for Lakerunner configdb (created via the postgresql provider)"
+  type        = string
+  default     = "config"
+}
+
+variable "postgresql_username" {
+  description = "Postgres master username"
+  type        = string
+  default     = "lakerunner"
+}
+
+variable "postgresql_password" {
+  description = "Postgres master password (leave empty to auto-generate)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "postgresql_allowed_cidr" {
+  description = "External CIDRs allowed to reach RDS on 5432. Defaults to 0.0.0.0/0 for POC ease; tighten for any real use."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+#####################
+# EKS
+#####################
+variable "enable_eks" {
+  description = "Provision an EKS cluster + node group + IRSA role for Lakerunner"
+  type        = bool
+  default     = true
+}
+
+variable "eks_kubernetes_version" {
+  description = "EKS control plane Kubernetes version"
+  type        = string
+  default     = "1.31"
+}
+
+variable "eks_node_min" {
+  description = "Minimum nodes in the managed node group"
+  type        = number
+  default     = 1
+}
+
+variable "eks_node_max" {
+  description = "Maximum nodes in the managed node group"
+  type        = number
+  default     = 10
+}
+
+variable "eks_node_instance_types" {
+  description = "EC2 instance types for the managed node group"
+  type        = list(string)
+  default     = ["t3.large"]
+}
+
+variable "eks_node_use_spot" {
+  description = "Use SPOT capacity for the managed node group"
+  type        = bool
+  default     = true
+}
+
+variable "eks_node_disk_size" {
+  description = "EBS volume size (GB) for nodes"
+  type        = number
+  default     = 50
+}

--- a/terraform/environments/azure-poc/main.tf
+++ b/terraform/environments/azure-poc/main.tf
@@ -366,18 +366,3 @@ resource "azurerm_kubernetes_cluster_node_pool" "user" {
   tags = local.common_tags
 }
 
-######################################
-# Kafka analog → Event Hubs (Kafka-compatible)
-# NOTE: Experimental/untested with LakeRunner. This block is gated by
-# var.enable_kafka and can be disabled or removed later if not needed.
-######################################
-resource "azurerm_eventhub_namespace" "ehns" {
-  count               = var.enable_kafka ? 1 : 0
-  name                = "lr-${var.installation_id}-eh-${random_string.sa.result}"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
-  sku                 = var.eventhub_sku
-  capacity            = var.eventhub_capacity
-  tags                = local.common_tags
-}
-// Only the Event Hubs namespace is provisioned here.

--- a/terraform/environments/azure-poc/outputs.tf
+++ b/terraform/environments/azure-poc/outputs.tf
@@ -16,12 +16,6 @@ output "storage_account_name" {
   description = "Storage account name (global unique)"
 }
 
-output "storage_account_access_key" {
-  value       = azurerm_storage_account.sa.primary_access_key
-  sensitive   = true
-  description = "Use with Azure Blob SDK/CLI (no S3 API)"
-}
-
 output "event_queue_name" {
   value       = azurerm_storage_queue.notifications.name
   description = "Queue receiving BlobCreated events (db/ excluded)"
@@ -70,10 +64,3 @@ output "aks_kube_config" {
   description = "kubeconfig (null if AKS disabled)"
 }
 
-##############
-# Kafka analog
-##############
-output "kafka_bootstrap_server" {
-  value       = var.enable_kafka ? "${azurerm_eventhub_namespace.ehns[0].name}.servicebus.windows.net:9093" : null
-  description = "Kafka-compatible bootstrap (SASL_SSL)"
-}

--- a/terraform/environments/azure-poc/variables.tf
+++ b/terraform/environments/azure-poc/variables.tf
@@ -117,7 +117,7 @@ variable "postgresql_storage_mb" {
 #####################
 variable "enable_aks" {
   type    = bool
-  default = false
+  default = true
 }
 
 variable "aks_cluster_name" {
@@ -205,20 +205,3 @@ variable "event_exclude_prefixes" {
   default     = ["db/"]
 }
 
-#####################
-# Kafka analog
-#####################
-variable "enable_kafka" {
-  type    = bool
-  default = false
-}
-
-variable "eventhub_sku" {
-  type    = string
-  default = "Standard"
-}
-
-variable "eventhub_capacity" {
-  type    = number
-  default = 1
-}

--- a/terraform/environments/gcp-poc/README.md
+++ b/terraform/environments/gcp-poc/README.md
@@ -2,6 +2,8 @@
 
 This Terraform configuration creates a minimal GCP environment perfect for evaluating Lakerunner.
 
+For AWS see `../aws-poc/`. For Azure see `../azure-poc/`.
+
 ## Quick Start (5 minutes)
 
 ### Prerequisites
@@ -34,7 +36,7 @@ gcloud auth application-default login
 1. **Download Configuration**
    ```bash
    # Clone or download the terraform files to your local machine
-   cd terraform/environments/poc/
+   cd terraform/environments/gcp-poc/
    ```
 
 2. **Configure Your Deployment**
@@ -75,11 +77,8 @@ The defaults work great for POC. Just set `project_id` and `region`.
 Add these to your `terraform.tfvars` if you have existing infra:
 
 ```hcl
-# Disable Kubernetes cluster
+# Bring your own Kubernetes cluster (you must wire Workload Identity yourself)
 enable_gke = false
-
-# Disable Kafka for event streaming
-enable_kafka = false
 
 # Use existing PostgreSQL (instead of creating new)
 create_postgresql = false
@@ -94,8 +93,7 @@ postgresql_instance_name = "your-existing-db"
 - **PostgreSQL Database** - For metadata storage
 - **Pub/Sub Topics** - For event notifications
 - **Service Accounts** - With appropriate permissions
-- **GKE Cluster** - Kubernetes for container workloads
-- **Managed Kafka** - Event streaming platform
+- **GKE Cluster** - Kubernetes for container workloads (default on)
 
 
 ## After Deployment

--- a/terraform/environments/gcp-poc/main.tf
+++ b/terraform/environments/gcp-poc/main.tf
@@ -289,14 +289,6 @@ resource "google_project_service" "container_api" {
   disable_on_destroy = false
 }
 
-# Enable Managed Kafka API
-resource "google_project_service" "managed_kafka_api" {
-  count              = var.enable_kafka ? 1 : 0
-  project            = var.project_id
-  service            = "managedkafka.googleapis.com"
-  disable_on_destroy = false
-}
-
 # Create VPC peering for Cloud SQL private networking
 # NOTE: Service networking connections are PROJECT-WIDE and shared between installations
 # This means destroying one installation can affect CloudSQL in other installations
@@ -333,7 +325,7 @@ resource "google_sql_database_instance" "lakerunner_postgresql" {
   settings {
     tier    = var.postgresql_machine_type
     edition = var.postgresql_edition
-    
+
     ip_configuration {
       ipv4_enabled    = false
       private_network = google_compute_network.lakerunner_vpc.id
@@ -521,66 +513,3 @@ resource "google_service_account_iam_member" "lakerunner_workload_identity" {
   member             = "serviceAccount:${var.project_id}.svc.id.goog[lakerunner/lakerunner]"
 }
 
-# HMAC keys for S3 compatibility
-resource "google_storage_hmac_key" "lakerunner_s3_key" {
-  service_account_email = google_service_account.lakerunner_poc.email
-}
-
-# Managed Kafka Cluster
-resource "google_managed_kafka_cluster" "lakerunner_kafka" {
-  count        = var.enable_kafka ? 1 : 0
-  cluster_id   = "lr-${var.installation_id}-kafka-${random_id.bucket_suffix.hex}"
-  location     = var.region
-  project      = var.project_id
-  
-  capacity_config {
-    vcpu_count   = var.kafka_cpu_count
-    memory_bytes = var.kafka_memory_gb * 1024 * 1024 * 1024
-  }
-  
-  rebalance_config {
-    mode = "AUTO_REBALANCE_ON_SCALE_UP"
-  }
-
-  gcp_config {
-    access_config {
-      network_configs {
-        subnet = google_compute_subnetwork.lakerunner_subnet.id
-      }
-    }
-  }
-
-  labels = local.common_labels
-  
-  depends_on = [google_project_service.managed_kafka_api]
-}
-
-# Kafka Topics for Lakerunner
-resource "google_managed_kafka_topic" "lakerunner_topics" {
-  for_each = var.enable_kafka ? toset([
-    "lakerunner-objstore-ingest-logs",
-    "lakerunner-objstore-ingest-metrics", 
-    "lakerunner-objstore-ingest-traces"
-  ]) : []
-  
-  project          = var.project_id
-  topic_id         = each.value
-  cluster          = google_managed_kafka_cluster.lakerunner_kafka[0].cluster_id
-  location         = var.region
-  partition_count  = 3
-  replication_factor = 3
-  
-  # Optional: Add retention configuration
-  configs = {
-    "retention.ms" = "604800000"  # 7 days
-    "segment.ms"   = "3600000"    # 1 hour
-  }
-}
-
-# IAM permissions for Kafka
-resource "google_project_iam_member" "lakerunner_kafka_admin" {
-  count   = var.enable_kafka ? 1 : 0
-  project = var.project_id
-  role    = "roles/managedkafka.admin"
-  member  = "serviceAccount:${google_service_account.lakerunner_poc.email}"
-}

--- a/terraform/environments/gcp-poc/outputs.tf
+++ b/terraform/environments/gcp-poc/outputs.tf
@@ -138,49 +138,6 @@ output "k8s_service_account_annotation_command" {
   value       = var.enable_gke ? "kubectl annotate serviceaccount lakerunner iam.gke.io/gcp-service-account=${google_service_account.lakerunner_k8s[0].email} -n lakerunner" : null
 }
 
-# S3 Compatibility outputs
-output "s3_access_key" {
-  description = "S3 compatible access key for the bucket"
-  value       = google_storage_hmac_key.lakerunner_s3_key.access_id
-}
-
-output "s3_secret_key" {
-  description = "S3 compatible secret key for the bucket"
-  value       = google_storage_hmac_key.lakerunner_s3_key.secret
-  sensitive   = true
-}
-
-output "s3_endpoint" {
-  description = "S3 compatible endpoint URL"
-  value       = "https://storage.googleapis.com"
-}
-
-output "s3_region" {
-  description = "S3 compatible region"
-  value       = "auto"
-}
-
-# Kafka outputs (when enabled)
-output "kafka_cluster_id" {
-  description = "Managed Kafka cluster ID (when enabled)"
-  value       = var.enable_kafka ? google_managed_kafka_cluster.lakerunner_kafka[0].cluster_id : null
-}
-
-output "kafka_cluster_name" {
-  description = "Kafka cluster name (when enabled)"
-  value       = var.enable_kafka ? google_managed_kafka_cluster.lakerunner_kafka[0].name : null
-}
-
-output "kafka_topics" {
-  description = "Created Kafka topics (when enabled)"
-  value       = var.enable_kafka ? [for topic in google_managed_kafka_topic.lakerunner_topics : topic.topic_id] : []
-}
-
-output "kafka_connection_info" {
-  description = "Kafka connection information (when enabled)"
-  value       = var.enable_kafka ? "Cluster: ${google_managed_kafka_cluster.lakerunner_kafka[0].cluster_id} (Location: ${var.region})" : "Kafka not enabled"
-}
-
 output "deployment_summary" {
   description = "POC deployment summary"
   value       = <<-EOT
@@ -188,11 +145,6 @@ output "deployment_summary" {
       Lakerunner Bucket: ${google_storage_bucket.lakerunner.name}
       Notifications Topic: ${google_pubsub_topic.object_notifications.name}
       Notifications Subscription: ${google_pubsub_subscription.lakerunner_notifications.name}
-      S3 Compatible Access:
-        Endpoint: https://storage.googleapis.com
-        Access Key: ${google_storage_hmac_key.lakerunner_s3_key.access_id}
-        Secret Key: [SENSITIVE - use 'terraform output -raw s3_secret_key' to view]
-        Region: auto
       ${var.create_postgresql ? "Database:\n      PostgreSQL Instance: ${google_sql_database_instance.lakerunner_postgresql[0].name}\n      Databases: ${var.postgresql_database_name}, ${var.postgresql_configdb_name}\n      User: ${var.postgresql_user}\n      Private IP: ${google_sql_database_instance.lakerunner_postgresql[0].private_ip_address}\n      Both lrdb and configdb ready for Lakerunner" : "Enable PostgreSQL with create_postgresql=true for database support"}
 
     Network:
@@ -204,7 +156,5 @@ output "deployment_summary" {
       Service Account: ${google_service_account.lakerunner_poc.email}
 
     ${var.enable_gke ? "Kubernetes:\n      GKE Cluster: ${google_container_cluster.lakerunner_gke[0].name}\n      Location: ${google_container_cluster.lakerunner_gke[0].location}\n      Nodes: ${var.gke_min_nodes}-${var.gke_max_nodes} ${var.gke_machine_type}\n      kubectl: gcloud container clusters get-credentials ${google_container_cluster.lakerunner_gke[0].name} --zone=${google_container_cluster.lakerunner_gke[0].location} --project=${var.project_id}" : "Enable Kubernetes with enable_gke=true for container workloads"}
-
-    ${var.enable_kafka ? "Kafka:\n      Cluster ID: ${google_managed_kafka_cluster.lakerunner_kafka[0].cluster_id}\n      Location: ${var.region}\n      Topics: lakerunner-objstore-ingest-logs, lakerunner-objstore-ingest-metrics, lakerunner-objstore-ingest-traces" : "Enable Kafka with enable_kafka=true for event streaming"}
   EOT
 }

--- a/terraform/environments/gcp-poc/terraform.tfvars.example
+++ b/terraform/environments/gcp-poc/terraform.tfvars.example
@@ -33,23 +33,18 @@ labels = {
 # No network configuration required - everything is self-contained
 
 # Kubernetes Options
-# Enable GKE cluster for container workloads (optional)
-enable_gke = true  # Set to false if you want to bring your own Kubernetes cluster
+# Enable GKE cluster for container workloads (default true)
+# Workload Identity is the only auth path for the Lakerunner workload, so
+# disabling this means you must bring your own cluster and wire up the
+# IAM-to-ServiceAccount mapping yourself.
+enable_gke = true
 
-# GKE Configuration 
+# GKE Configuration
 gke_min_nodes    = 1
 gke_max_nodes    = 10
 gke_machine_type = "e2-standard-4"
 gke_use_spot     = true
 gke_disk_size_gb = 50
-
-# Kafka Configuration
-# Enable Managed Kafka for event streaming (optional)
-enable_kafka = false  # Set to false if you already have a Kafka provisioned 
-
-# Kafka Instance Settings 
-kafka_cpu_count  = 1
-kafka_memory_gb  = 3
 
 # PostgreSQL Configuration
 # Option 1: Create new PostgreSQL instance (default, easiest for POC)

--- a/terraform/environments/gcp-poc/variables.tf
+++ b/terraform/environments/gcp-poc/variables.tf
@@ -45,7 +45,7 @@ variable "labels" {
 variable "enable_gke" {
   description = "Enable GKE cluster for container workloads"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "gke_min_nodes" {
@@ -76,25 +76,6 @@ variable "gke_disk_size_gb" {
   description = "Disk size in GB for GKE nodes"
   type        = number
   default     = 50
-}
-
-# Kafka Configuration
-variable "enable_kafka" {
-  description = "Enable Managed Kafka cluster for event streaming"
-  type        = bool
-  default     = false
-}
-
-variable "kafka_cpu_count" {
-  description = "CPU count per Kafka broker"
-  type        = number
-  default     = 1
-}
-
-variable "kafka_memory_gb" {
-  description = "Memory in GB per Kafka broker"
-  type        = number
-  default     = 3
 }
 
 # PostgreSQL Configuration

--- a/terraform/providers/aws/provider.tf
+++ b/terraform/providers/aws/provider.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = merge(var.tags, {
+      environment = var.environment
+      managed-by  = "terraform"
+    })
+  }
+}

--- a/terraform/providers/aws/variables.tf
+++ b/terraform/providers/aws/variables.tf
@@ -1,0 +1,16 @@
+variable "region" {
+  description = "The AWS region for resources"
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "environment" {
+  description = "Environment name (poc, dev, staging, prod)"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/providers/aws/versions.tf
+++ b/terraform/providers/aws/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/terraform/providers/gcp/versions.tf
+++ b/terraform/providers/gcp/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.0"
-  
+
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/test.sh
+++ b/test.sh
@@ -3,20 +3,29 @@ set -e
 
 echo "Running Terraform tests..."
 
-# Navigate to POC environment
-cd terraform/environments/poc
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+ENVIRONMENTS="gcp-poc azure-poc aws-poc"
 
-echo "terraform fmt -check"
-terraform fmt -check -recursive
+echo "==> terraform fmt -check (recursive)"
+(cd "$REPO_ROOT/terraform" && terraform fmt -check -recursive)
 
-echo "terraform validate"
-terraform validate
+for env in $ENVIRONMENTS; do
+  echo "==> terraform validate ($env)"
+  (
+    cd "$REPO_ROOT/terraform/environments/$env"
+    terraform init -backend=false -input=false >/dev/null
+    terraform validate
+  )
+done
 
-echo "terraform plan (dry-run)"
-# Use our test project ID
-terraform plan -var="project_id=lakerunner-terraform" -target=google_storage_bucket.lakerunner -out=test.plan
-
-echo "Cleaning up test artifacts"
-rm -f test.plan
+echo "==> terraform plan (gcp-poc dry-run with synthetic project ID)"
+(
+  cd "$REPO_ROOT/terraform/environments/gcp-poc"
+  terraform plan \
+    -var="project_id=lakerunner-terraform" \
+    -target=google_storage_bucket.lakerunner \
+    -out=test.plan
+  rm -f test.plan
+)
 
 echo "All tests passed!"


### PR DESCRIPTION
## Summary
- Adds `terraform/environments/aws-poc/` (VPC, S3+SQS, EKS+IRSA, RDS Postgres) mirroring the existing GCP/Azure POC pattern
- Renames `terraform/environments/poc/` to `terraform/environments/gcp-poc/` so the three clouds are symmetric peers
- Removes Kafka entirely from `gcp-poc` (Managed Kafka) and `azure-poc` (Event Hubs)
- Removes static object-store credentials: HMAC keys on GCP, storage account access key on Azure, no IAM user on AWS. Workload identity (IRSA / Workload Identity / Workload Identity) is the only auth path.
- Defaults the managed Kubernetes cluster to on across all three POCs (`enable_eks/gke/aks = true`); without it there is no credential path for the workload
- Updates `Makefile` and `test.sh` so `fmt -check` and `validate` cover all three environments; `plan` stays GCP-only since the others need real credentials
- Spec for the change at `docs/superpowers/specs/2026-05-04-aws-poc-design.md`

## Notable trade-offs
- AWS RDS is `publicly_accessible = true` with `postgresql_allowed_cidr` defaulting to `0.0.0.0/0`. This lets terraform create the second `config` database via the `cyrilgdn/postgresql` provider and lets POC users `psql` from their workstation. Tighten the variable for any non-throwaway use; called out in the variable description, the AWS POC README, and an inline comment.
- Default AWS POC apply is meter-running (~$150/mo idle: EKS control plane, NAT Gateway, RDS, one Spot t3.large). Cost breakdown is in the AWS POC README.
- The `poc/` -> `gcp-poc/` rename does not move any existing local `terraform.tfstate`. Existing deployers either `mv` their state into the new directory or re-init. Documented in `UPGRADE.md`.

## Test plan
- [x] `make fmt` clean
- [x] `make validate` succeeds for `gcp-poc`, `azure-poc`, `aws-poc` (no credentials needed)
- [x] `make test` (fmt-check + validate all three + targeted gcp plan) passes
- [ ] Real `terraform apply` of `aws-poc` in a sandbox AWS account to smoke-test EKS + IRSA + RDS provisioning