### PR TITLE
Tighten aws-poc S3 notifications to otel-raw/ prefix

### DIFF
--- a/terraform/environments/aws-poc/README.md
+++ b/terraform/environments/aws-poc/README.md
@@ -49,8 +49,8 @@ For GCP see `../gcp-poc/`. For Azure see `../azure-poc/`.
 ## What Gets Created
 
 - **VPC** with two public + two private subnets across two AZs, single NAT Gateway
-- **S3 bucket** for telemetry data, with all `s3:ObjectCreated:*` events routed to:
-- **SQS queue** consumed by Lakerunner. The consumer filters out the `db/` prefix (parity with the GCP POC).
+- **S3 bucket** for telemetry data. `s3:ObjectCreated:*` events under the `otel-raw/` prefix fan out to:
+- **SQS queue** consumed by Lakerunner. Other prefixes (e.g. `db/`) do not generate notifications.
 - **EKS cluster** with one managed node group (Spot by default, autoscaling 1-10)
 - **OIDC provider** + **IAM role** for IRSA, scoped to ServiceAccount `lakerunner/lakerunner`, with permissions on the bucket and the queue
 - **RDS Postgres** (publicly accessible for POC ease) with two databases: `lakerunner` and `config`

--- a/terraform/environments/aws-poc/main.tf
+++ b/terraform/environments/aws-poc/main.tf
@@ -234,14 +234,15 @@ resource "aws_sqs_queue_policy" "notifications" {
   })
 }
 
-# All ObjectCreated events go to the queue. The Lakerunner consumer filters
-# out the db/ path, matching the GCP POC's behavior.
+# Only otel-raw/ object creates fan out to SQS. Other prefixes (db/, etc.)
+# do not generate notifications.
 resource "aws_s3_bucket_notification" "lakerunner" {
   bucket = aws_s3_bucket.lakerunner.id
 
   queue {
-    queue_arn = aws_sqs_queue.notifications.arn
-    events    = ["s3:ObjectCreated:*"]
+    queue_arn     = aws_sqs_queue.notifications.arn
+    events        = ["s3:ObjectCreated:*"]
+    filter_prefix = "otel-raw/"
   }
 
   depends_on = [aws_sqs_queue_policy.notifications]


### PR DESCRIPTION
## Summary
- Adds `filter_prefix = "otel-raw/"` to the `aws_s3_bucket_notification.lakerunner` queue rule so only object creates under `otel-raw/` fan out to SQS
- Removes the now-stale comment / README line about consumer-side `db/` filtering on AWS, since `db/` (and any other prefix) no longer hits the queue at all

## Test plan
- [x] `make test` passes (fmt-check, validate gcp/azure/aws, gcp targeted plan)
- [ ] Manual smoke test in a sandbox AWS account: `aws s3 cp` an object to `otel-raw/...` and confirm an SQS message arrives; confirm a write to a different prefix produces no message