### PR TITLE
Tighten gcp-poc and azure-poc notifications to otel-raw/ prefix

### DIFF
--- a/terraform/environments/azure-poc/main.tf
+++ b/terraform/environments/azure-poc/main.tf
@@ -73,8 +73,8 @@ resource "azurerm_storage_management_policy" "cleanup" {
 }
 
 ######################################
-# Eventing: BlobCreated → Storage Queue
-# (GCS Notification → Pub/Sub analog; excludes db/ by default)
+# Eventing: BlobCreated under otel-raw/ → Storage Queue
+# (GCS Notification → Pub/Sub analog)
 ######################################
 resource "azurerm_storage_queue" "notifications" {
   name                 = "lr-${var.installation_id}-notifications"
@@ -97,20 +97,10 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "blob_created" {
 
   included_event_types = ["Microsoft.Storage.BlobCreated"]
 
-  # Limit to the "lakerunner" container
+  # Only otel-raw/ blob creates inside the lakerunner container fan out to
+  # the queue. Other prefixes (db/, etc.) do not generate notifications.
   subject_filter {
-    subject_begins_with = "/blobServices/default/containers/${azurerm_storage_container.lakerunner.name}/blobs/"
-  }
-
-  # Exclude prefixes like db/
-  dynamic "advanced_filter" {
-    for_each = var.event_exclude_prefixes
-    content {
-      string_not_begins_with {
-        key    = "subject"
-        values = ["/blobServices/default/containers/${azurerm_storage_container.lakerunner.name}/blobs/${advanced_filter.value}"]
-      }
-    }
+    subject_begins_with = "/blobServices/default/containers/${azurerm_storage_container.lakerunner.name}/blobs/otel-raw/"
   }
 
   storage_queue_endpoint {

--- a/terraform/environments/azure-poc/variables.tf
+++ b/terraform/environments/azure-poc/variables.tf
@@ -196,12 +196,3 @@ variable "aks_enable_workload_identity" {
   default = true
 }
 
-#####################
-# Eventing (Pub/Sub analog)
-#####################
-variable "event_exclude_prefixes" {
-  description = "Blob path prefixes to exclude from notifications (e.g. [\"db/\"])"
-  type        = list(string)
-  default     = ["db/"]
-}
-

--- a/terraform/environments/gcp-poc/main.tf
+++ b/terraform/environments/gcp-poc/main.tf
@@ -91,15 +91,15 @@ resource "google_pubsub_subscription" "lakerunner_notifications" {
   }
 }
 
-# Storage notification for all objects except db/ path
+# Only otel-raw/ object creates fan out to Pub/Sub. Other prefixes (db/, etc.)
+# do not generate notifications.
 resource "google_storage_notification" "object_create_notify" {
-  bucket         = google_storage_bucket.lakerunner.name
-  topic          = google_pubsub_topic.object_notifications.id
-  event_types    = ["OBJECT_FINALIZE"]
-  payload_format = "JSON_API_V1"
+  bucket             = google_storage_bucket.lakerunner.name
+  topic              = google_pubsub_topic.object_notifications.id
+  event_types        = ["OBJECT_FINALIZE"]
+  payload_format     = "JSON_API_V1"
+  object_name_prefix = "otel-raw/"
 
-  # This will notify on all objects - we'll filter out db/ in the subscriber
-  # GCS notifications don't support path exclusions, only inclusions
   depends_on = [
     google_pubsub_topic_iam_member.storage_publisher
   ]


### PR DESCRIPTION
## Summary
Mirrors PR #4 (which did this for `aws-poc`) on the other two clouds.

- `gcp-poc`: adds `object_name_prefix = "otel-raw/"` to `google_storage_notification.object_create_notify`.
- `azure-poc`: changes `subject_filter.subject_begins_with` to point at `.../containers/lakerunner/blobs/otel-raw/`, removes the now-dead `advanced_filter` exclusion block and the unused `var.event_exclude_prefixes`.

After this, all three POCs only fan out blob-create events under `otel-raw/`. Other prefixes (`db/`, etc.) do not generate notifications.

## Test plan
- [x] `make test` passes (fmt-check, validate gcp/azure/aws, gcp targeted plan)
- [ ] Manual smoke test in sandbox GCP and Azure projects: write to `otel-raw/...` and confirm a queue/subscription message; write to a different prefix and confirm no message