### PR TITLE
Switch to tofu; bump aws-poc Postgres/EKS defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: opentofu/setup-opentofu@v1
         with:
-          terraform_version: "1.9.8"
-          terraform_wrapper: false
+          tofu_version: "1.11.6"
+          tofu_wrapper: false
 
-      - name: terraform fmt -check
-        run: terraform fmt -check -recursive
-        working-directory: terraform
-
-      - name: make validate
-        run: make validate
+      - name: make test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 ENVIRONMENTS := gcp-poc azure-poc aws-poc
 
+TF ?= tofu
+
 # Default target
 help: ## Show this help message
 	@echo "Lakerunner Terraform"
@@ -9,26 +11,26 @@ help: ## Show this help message
 	@echo "Available targets:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-test: ## Run all tests (format check + validate all envs + plan gcp-poc)
-	@./test.sh
+test: ## Run all tests (format check + validate all envs)
+	@TF=$(TF) ./test.sh
 
 check: test ## Alias for test
 
 fmt: ## Format Terraform files (recursive across all envs)
 	@echo "Formatting Terraform files..."
-	@cd terraform && terraform fmt -recursive
+	@cd terraform && $(TF) fmt -recursive
 
 validate: ## Validate all environments (no credentials needed)
 	@for env in $(ENVIRONMENTS); do \
 		echo "==> Validating $$env"; \
-		(cd terraform/environments/$$env && terraform init -backend=false -input=false >/dev/null && terraform validate) || exit 1; \
+		(cd terraform/environments/$$env && $(TF) init -backend=false -input=false >/dev/null && $(TF) validate) || exit 1; \
 	done
 
 plan: plan-gcp ## Alias for plan-gcp
 
-plan-gcp: ## Run terraform plan against gcp-poc with the test project ID
-	@echo "Running terraform plan against gcp-poc..."
-	@cd terraform/environments/gcp-poc && terraform plan -var="project_id=lakerunner-terraform"
+plan-gcp: ## Run plan against gcp-poc with the test project ID
+	@echo "Running plan against gcp-poc..."
+	@cd terraform/environments/gcp-poc && $(TF) plan -var="project_id=lakerunner-terraform"
 
 clean: ## Clean up temporary files
 	@echo "Cleaning up..."

--- a/terraform/environments/aws-poc/terraform.tfvars.example
+++ b/terraform/environments/aws-poc/terraform.tfvars.example
@@ -29,7 +29,7 @@ vpc_cidr = "10.0.0.0/16"
 # for the Lakerunner workload, so disabling this means you must bring
 # your own cluster and wire IAM-to-ServiceAccount mapping yourself.
 enable_eks              = true
-eks_kubernetes_version  = "1.31"
+eks_kubernetes_version  = "1.35"
 eks_node_min            = 1
 eks_node_max            = 10
 eks_node_instance_types = ["t3.large"]
@@ -40,7 +40,7 @@ eks_node_disk_size      = 50
 create_postgresql            = true
 postgresql_instance_class    = "db.t4g.medium"
 postgresql_allocated_storage = 20
-postgresql_engine_version    = "17"
+postgresql_engine_version    = "18"
 
 # Leave postgresql_password empty for auto-generation.
 # postgresql_password = ""

--- a/terraform/environments/aws-poc/variables.tf
+++ b/terraform/environments/aws-poc/variables.tf
@@ -51,7 +51,7 @@ variable "create_postgresql" {
 variable "postgresql_engine_version" {
   description = "Postgres engine major version"
   type        = string
-  default     = "17"
+  default     = "18"
 }
 
 variable "postgresql_instance_class" {
@@ -109,7 +109,7 @@ variable "enable_eks" {
 variable "eks_kubernetes_version" {
   description = "EKS control plane Kubernetes version"
   type        = string
-  default     = "1.31"
+  default     = "1.35"
 }
 
 variable "eks_node_min" {

--- a/test.sh
+++ b/test.sh
@@ -1,31 +1,23 @@
 #!/bin/bash
 set -e
 
-echo "Running Terraform tests..."
+TF="${TF:-tofu}"
+
+echo "Running Terraform tests with: $TF"
 
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 ENVIRONMENTS="gcp-poc azure-poc aws-poc"
 
-echo "==> terraform fmt -check (recursive)"
-(cd "$REPO_ROOT/terraform" && terraform fmt -check -recursive)
+echo "==> $TF fmt -check (recursive)"
+(cd "$REPO_ROOT/terraform" && "$TF" fmt -check -recursive)
 
 for env in $ENVIRONMENTS; do
-  echo "==> terraform validate ($env)"
+  echo "==> $TF validate ($env)"
   (
     cd "$REPO_ROOT/terraform/environments/$env"
-    terraform init -backend=false -input=false >/dev/null
-    terraform validate
+    "$TF" init -backend=false -input=false >/dev/null
+    "$TF" validate
   )
 done
-
-echo "==> terraform plan (gcp-poc dry-run with synthetic project ID)"
-(
-  cd "$REPO_ROOT/terraform/environments/gcp-poc"
-  terraform plan \
-    -var="project_id=lakerunner-terraform" \
-    -target=google_storage_bucket.lakerunner \
-    -out=test.plan
-  rm -f test.plan
-)
 
 echo "All tests passed!"


### PR DESCRIPTION
## Summary
- Makefile and `test.sh` invoke `$(TF)` (defaults to `tofu`); `make test` no longer runs a `plan` step
- CI swaps `hashicorp/setup-terraform` for `opentofu/setup-opentofu` and just runs `make test`
- `aws-poc` defaults: Postgres `17` -> `18`, EKS `1.31` -> `1.35`

## Test plan
- [x] `make test` passes locally with tofu
- [x] `tofu plan` + `tofu apply` against a real AWS account succeeds with the prior `1.31`/`17` config
- [ ] CI green on this PR